### PR TITLE
Elevate policy controls into top React control bar

### DIFF
--- a/assets/ifp-logo.svg
+++ b/assets/ifp-logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="56" viewBox="0 0 180 56" role="img" aria-labelledby="ifpTitle ifpDesc">
+  <title id="ifpTitle">IFP Logo</title>
+  <desc id="ifpDesc">Rounded rectangle containing the letters IFP with a gradient accent underline.</desc>
+  <defs>
+    <linearGradient id="ifpGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6f3cff" />
+      <stop offset="50%" stop-color="#5b21b6" />
+      <stop offset="100%" stop-color="#1e1b4b" />
+    </linearGradient>
+    <linearGradient id="ifpAccent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#22d3ee" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+    <filter id="ifpShadow" x="-10%" y="-30%" width="120%" height="160%">
+      <feOffset dy="2" in="SourceAlpha" result="shadowOffset" />
+      <feGaussianBlur in="shadowOffset" stdDeviation="3" result="shadowBlur" />
+      <feColorMatrix in="shadowBlur" type="matrix" values="0 0 0 0 0.13 0 0 0 0 0.07 0 0 0 0 0.24 0 0 0 0.35 0" result="shadow" />
+      <feBlend in="SourceGraphic" in2="shadow" mode="normal" />
+    </filter>
+  </defs>
+  <g filter="url(#ifpShadow)">
+    <rect x="4" y="4" width="172" height="48" rx="18" fill="#0f172a" />
+    <rect x="4" y="4" width="172" height="48" rx="18" fill="url(#ifpGradient)" opacity="0.95" />
+  </g>
+  <text x="26" y="35" font-family="'Poppins', 'Inter', sans-serif" font-size="28" font-weight="700" fill="white" letter-spacing="2">
+    IFP
+  </text>
+  <path d="M120 38 H156" stroke="url(#ifpAccent)" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,1233 +1,1203 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>H-1B Policy Lab Preview</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    :root {
-      color-scheme: light;
-    }
-    body {
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      margin: 0;
-      padding: 2.5rem;
-      background: radial-gradient(120% 120% at 20% 0%, rgba(177, 140, 255, 0.35) 0%, rgba(111, 72, 182, 0.12) 45%, rgba(36, 19, 54, 0.08) 100%), #f7f5ff;
-      color: #241336;
-      transition: background 0.35s ease;
-    }
-    body.civil-war-canvas {
-      background: radial-gradient(115% 120% at 15% -10%, rgba(196, 173, 143, 0.52) 0%, rgba(181, 150, 118, 0.38) 35%, rgba(104, 83, 59, 0.35) 100%), #f3ebe0;
-      color: #2b2118;
-    }
-    main {
-      max-width: 1040px;
-      margin: 0 auto;
-      background: #ffffff;
-      border-radius: 22px;
-      box-shadow: 0 32px 60px rgba(36, 19, 54, 0.16);
-      padding: 3rem 3.5rem;
-      border: 1px solid rgba(177, 140, 255, 0.35);
-      transition: border 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-    }
-    body.civil-war-canvas main {
-      background: #fdf8f0;
-      border-color: rgba(143, 102, 54, 0.42);
-      box-shadow: 0 32px 60px rgba(59, 45, 34, 0.18);
-    }
-    header {
-      display: flex;
-      align-items: center;
-      gap: 1.5rem;
-      margin-bottom: 2.5rem;
-    }
-    header img {
-      width: 160px;
-      height: auto;
-      border-radius: 18px;
-      box-shadow: 0 18px 32px rgba(76, 44, 127, 0.18);
-      transition: filter 0.3s ease, box-shadow 0.3s ease;
-    }
-    body.civil-war-canvas header img {
-      filter: sepia(0.55) saturate(0.85) contrast(0.95);
-      box-shadow: 0 18px 32px rgba(59, 45, 34, 0.24);
-    }
-    header h1 {
-      margin: 0;
-      font-size: 2.5rem;
-      letter-spacing: -0.02em;
-    }
-    p.lede {
-      font-size: 1.1rem;
-      color: rgba(36, 19, 54, 0.78);
-      line-height: 1.7;
-      transition: color 0.3s ease;
-    }
-    body.civil-war-canvas p.lede {
-      color: rgba(72, 56, 42, 0.88);
-    }
-    section.narrative {
-      margin-bottom: 2.5rem;
-      line-height: 1.75;
-      color: rgba(36, 19, 54, 0.88);
-      transition: color 0.3s ease;
-    }
-    body.civil-war-canvas section.narrative {
-      color: rgba(72, 56, 42, 0.88);
-    }
-    section.narrative h2 {
-      font-size: 1.4rem;
-      margin-top: 2rem;
-      margin-bottom: 0.75rem;
-      color: #4c2c7f;
-      transition: color 0.3s ease;
-    }
-    body.civil-war-canvas section.narrative h2 {
-      color: #872f1b;
-    }
-    .h1b-lab {
-      --lab-font: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      --lab-ink: #241336;
-      --lab-muted: rgba(36, 19, 54, 0.65);
-      --lab-heading-color: #4c2c7f;
-      --lab-summary-border: #b18cff;
-      --lab-summary-bg: rgba(244, 236, 255, 0.88);
-      --lab-panel-bg: linear-gradient(135deg, rgba(244, 236, 255, 0.95), rgba(210, 185, 255, 0.9));
-      --lab-panel-border: rgba(76, 44, 127, 0.2);
-      --lab-panel-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68);
-      --lab-switch-bg: rgba(255, 255, 255, 0.75);
-      --lab-switch-border: rgba(76, 44, 127, 0.15);
-      --lab-switch-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
-      --lab-switch-active-start: #5b21b6;
-      --lab-switch-active-end: #7c3aed;
-      --lab-switch-active-shadow: 0 10px 24px rgba(91, 33, 182, 0.35);
-      --lab-switch-text: #ffffff;
-      --lab-switch-subtext: rgba(255, 255, 255, 0.85);
-      --lab-accent-color: #b18cff;
-      --lab-card-bg: linear-gradient(160deg, rgba(244, 236, 255, 0.98), rgba(210, 185, 255, 0.7));
-      --lab-card-border: rgba(76, 44, 127, 0.18);
-      --lab-card-heading: rgba(76, 44, 127, 0.75);
-      --lab-footnote: rgba(36, 19, 54, 0.7);
-      --lab-chart-bg: rgba(244, 236, 255, 0.9);
-      --lab-chart-border: rgba(177, 140, 255, 0.3);
-      --lab-theme-button-bg: rgba(255, 255, 255, 0.85);
-      --lab-theme-button-border: rgba(76, 44, 127, 0.35);
-      --lab-theme-button-hover: rgba(91, 33, 182, 0.12);
-      --lab-theme-button-color: #241336;
-      --lab-theme-button-subtext: rgba(36, 19, 54, 0.65);
-      --lab-axis-color: rgba(36, 19, 54, 0.75);
-      --lab-axis-strong: rgba(36, 19, 54, 0.85);
-      --lab-axis-line: #cbd5f5;
-      --lab-axis-tick: #94a3b8;
-      --lab-gridline: rgba(148, 163, 184, 0.25);
-      --lab-chart-baseline: #3f3d56;
-      --lab-chart-highlight: #5b21b6;
-      --lab-chart-accent: #7c3aed;
-      --lab-chart-muted: rgba(63, 61, 86, 0.55);
-      --lab-campaign-bg: rgba(255, 255, 255, 0.9);
-      --lab-campaign-border: rgba(177, 140, 255, 0.3);
-      --lab-campaign-heading: #4c2c7f;
-      font-family: var(--lab-font);
-      color: var(--lab-ink);
-      margin-top: 1.75rem;
-    }
-    .h1b-lab.civil-war {
-      --lab-font: 'Libre Baskerville', 'Times New Roman', serif;
-      --lab-ink: #2b2118;
-      --lab-muted: rgba(72, 56, 42, 0.75);
-      --lab-heading-color: #1b3a6b;
-      --lab-summary-border: #872f1b;
-      --lab-summary-bg: rgba(245, 235, 220, 0.9);
-      --lab-panel-bg: linear-gradient(135deg, rgba(246, 236, 220, 0.95), rgba(224, 203, 170, 0.88));
-      --lab-panel-border: rgba(117, 82, 53, 0.35);
-      --lab-panel-shadow: inset 0 1px 0 rgba(255, 247, 235, 0.8);
-      --lab-switch-bg: rgba(252, 246, 235, 0.82);
-      --lab-switch-border: rgba(117, 82, 53, 0.25);
-      --lab-switch-shadow: inset 0 1px 0 rgba(255, 248, 238, 0.9);
-      --lab-switch-active-start: #1b3a6b;
-      --lab-switch-active-end: #872f1b;
-      --lab-switch-active-shadow: 0 12px 28px rgba(59, 45, 34, 0.35);
-      --lab-switch-text: #fff8ec;
-      --lab-switch-subtext: rgba(255, 240, 220, 0.85);
-      --lab-accent-color: #8f4f2a;
-      --lab-card-bg: linear-gradient(160deg, rgba(249, 239, 224, 0.96), rgba(228, 207, 174, 0.76));
-      --lab-card-border: rgba(117, 82, 53, 0.35);
-      --lab-card-heading: rgba(39, 61, 92, 0.85);
-      --lab-footnote: rgba(72, 56, 42, 0.78);
-      --lab-chart-bg: rgba(245, 235, 220, 0.92);
-      --lab-chart-border: rgba(143, 102, 54, 0.35);
-      --lab-theme-button-bg: rgba(236, 223, 205, 0.94);
-      --lab-theme-button-border: rgba(117, 82, 53, 0.45);
-      --lab-theme-button-hover: rgba(137, 104, 64, 0.22);
-      --lab-theme-button-color: #2b2118;
-      --lab-theme-button-subtext: rgba(72, 56, 42, 0.75);
-      --lab-axis-color: rgba(72, 56, 42, 0.78);
-      --lab-axis-strong: rgba(59, 45, 34, 0.85);
-      --lab-axis-line: #d1bfa5;
-      --lab-axis-tick: #a78963;
-      --lab-gridline: rgba(167, 137, 99, 0.3);
-      --lab-chart-baseline: #5b5045;
-      --lab-chart-highlight: #1b3a6b;
-      --lab-chart-accent: #872f1b;
-      --lab-chart-muted: rgba(59, 45, 34, 0.6);
-      --lab-campaign-bg: rgba(241, 229, 210, 0.94);
-      --lab-campaign-border: rgba(143, 102, 54, 0.42);
-      --lab-campaign-heading: #872f1b;
-    }
-    .theme-toolbar {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 1.25rem;
-      margin-bottom: 1.5rem;
-      flex-wrap: wrap;
-    }
-    .theme-toggle {
-      border: 1px solid var(--lab-theme-button-border);
-      background: var(--lab-theme-button-bg);
-      border-radius: 0.95rem;
-      padding: 0.75rem 1.2rem;
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.35rem;
-      cursor: pointer;
-      color: var(--lab-theme-button-color);
-      font-weight: 600;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-      box-shadow: 0 12px 26px rgba(36, 19, 54, 0.1);
-    }
-    .theme-toggle span {
-      font-size: 0.8rem;
-      font-weight: 500;
-      color: var(--lab-theme-button-subtext);
-    }
-    .theme-toggle:hover {
-      background: var(--lab-theme-button-hover);
-      transform: translateY(-1px);
-      box-shadow: 0 16px 28px rgba(36, 19, 54, 0.12);
-    }
-    .theme-toggle:active {
-      transform: translateY(0);
-      box-shadow: 0 8px 20px rgba(36, 19, 54, 0.1);
-    }
-    .h1b-policy-controls {
-      background: var(--lab-panel-bg);
-      border-radius: 1.35rem;
-      padding: 2rem 2.25rem;
-      margin: 2.5rem 0 1.75rem;
-      border: 1px solid var(--lab-panel-border);
-      box-shadow: var(--lab-panel-shadow);
-    }
-    .h1b-policy-controls h2 {
-      margin-top: 0;
-      margin-bottom: 1.25rem;
-      font-size: 1.35rem;
-      color: var(--lab-heading-color);
-    }
-    .control-stack {
-      display: flex;
-      flex-direction: column;
-      gap: 0.85rem;
-      margin-bottom: 1.5rem;
-    }
-    .control-label {
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-      font-size: 0.78rem;
-      color: var(--lab-muted);
-    }
-    .control-help {
-      font-size: 0.8rem;
-      color: var(--lab-muted);
-      margin: 0;
-    }
-    .scenario-switch {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-      gap: 0.5rem;
-      padding: 0.4rem;
-      border-radius: 999px;
-      background: var(--lab-switch-bg);
-      border: 1px solid var(--lab-switch-border);
-      box-shadow: var(--lab-switch-shadow);
-    }
-    .scenario-switch button {
-      border: none;
-      background: transparent;
-      padding: 0.7rem 1.1rem;
-      border-radius: 999px;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.18s ease-in-out;
-      color: var(--lab-muted);
-      display: flex;
-      flex-direction: column;
-      gap: 0.15rem;
-      min-height: 64px;
-    }
-    .scenario-switch button strong {
-      font-size: 0.95rem;
-      letter-spacing: -0.01em;
-      color: var(--lab-ink);
-    }
-    .scenario-switch button span {
-      font-size: 0.75rem;
-    }
-    .scenario-switch button.active {
-      background: linear-gradient(135deg, var(--lab-switch-active-start) 0%, var(--lab-switch-active-end) 100%);
-      color: var(--lab-switch-text);
-      box-shadow: var(--lab-switch-active-shadow);
-    }
-    .scenario-switch button.active strong,
-    .scenario-switch button.active span {
-      color: var(--lab-switch-subtext);
-    }
-    .control-grid {
-      display: grid;
-      grid-template-columns: minmax(220px, 2fr) minmax(180px, 3fr) auto;
-      align-items: center;
-      gap: 1rem 1.5rem;
-      margin-bottom: 1.25rem;
-    }
-    .control-grid input[type="range"] {
-      width: 100%;
-      accent-color: var(--lab-accent-color);
-    }
-    .control-grid .value {
-      font-weight: 700;
-      color: var(--lab-heading-color);
-    }
-    fieldset.policy-toggles {
-      margin: 0;
-      padding: 1.1rem 1.25rem 1.4rem;
-      border-radius: 1.1rem;
-      border: 1px solid var(--lab-panel-border);
-      display: grid;
-      gap: 0.7rem;
-      background: var(--lab-switch-bg);
-    }
-    fieldset.policy-toggles legend {
-      font-weight: 600;
-      color: var(--lab-heading-color);
-      padding: 0 0.35rem;
-    }
-    fieldset.policy-toggles label {
-      display: flex;
-      align-items: center;
-      gap: 0.6rem;
-      font-size: 0.95rem;
-      color: var(--lab-ink);
-    }
-    fieldset.policy-toggles input[type="checkbox"] {
-      accent-color: var(--lab-accent-color);
-    }
-    .h1b-metrics {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 1.15rem;
-      margin: 1.75rem 0;
-    }
-    .metric-card {
-      background: var(--lab-card-bg);
-      border-radius: 1rem;
-      padding: 1rem 1.2rem;
-      border: 1px solid var(--lab-card-border);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62);
-    }
-    .metric-card h4 {
-      margin: 0;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lab-card-heading);
-    }
-    .metric-value {
-      margin: 0.35rem 0 0;
-      font-size: 2rem;
-      font-weight: 700;
-      color: var(--lab-ink);
-    }
-    .metric-footnote {
-      margin: 0.3rem 0 0;
-      font-size: 0.85rem;
-      color: var(--lab-footnote);
-    }
-    .chart-card {
-      margin-bottom: 1.85rem;
-      padding: 1.4rem 1.55rem 1.7rem;
-      border-radius: 1.2rem;
-      background: var(--lab-chart-bg);
-      border: 1px solid var(--lab-chart-border);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-    }
-    .chart-card h3 {
-      margin: 0 0 0.85rem;
-      font-size: 1.15rem;
-      color: var(--lab-heading-color);
-    }
-    .chart-card svg {
-      width: 100%;
-      height: auto;
-      overflow: visible;
-    }
-    .h1b-summary {
-      margin: 2.2rem 0 1.2rem;
-      padding: 1.5rem 1.7rem;
-      border-left: 5px solid var(--lab-summary-border);
-      background: var(--lab-summary-bg);
-      border-radius: 0.95rem;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-    }
-    .h1b-summary h3 {
-      margin: 0 0 0.65rem;
-      color: var(--lab-heading-color);
-    }
-    .h1b-campaign-log {
-      margin: 0 0 2rem;
-      padding: 1.3rem 1.5rem;
-      border-radius: 0.9rem;
-      border: 1px solid var(--lab-campaign-border);
-      background: var(--lab-campaign-bg);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
-    }
-    .h1b-campaign-log h4 {
-      margin: 0 0 0.65rem;
-      font-size: 1rem;
-      color: var(--lab-campaign-heading);
-    }
-    .h1b-campaign-log ul {
-      margin: 0;
-      padding-left: 1.2rem;
-      display: grid;
-      gap: 0.4rem;
-      color: var(--lab-ink);
-    }
-    .lab-notes-heading {
-      font-size: 1.15rem;
-      margin: 0 0 0.75rem;
-      color: var(--lab-heading-color);
-    }
-    .lab-notes {
-      list-style: disc;
-      padding-left: 1.2rem;
-      display: grid;
-      gap: 0.6rem;
-      color: var(--lab-ink);
-    }
-    .lab-notes strong {
-      color: var(--lab-heading-color);
-    }
-    @media (max-width: 720px) {
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>IFP H-1B Policy Lab</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg-surface: #f7f8fc;
+        --bg-panel: #ffffff;
+        --bg-emphasis: #ede9fe;
+        --bg-chip: rgba(99, 102, 241, 0.08);
+        --ink-strong: #181236;
+        --ink-soft: rgba(24, 18, 54, 0.78);
+        --ink-subtle: rgba(24, 18, 54, 0.55);
+        --brand: #5b21b6;
+        --brand-strong: #4c1d95;
+        --brand-soft: #7c3aed;
+        --border-soft: rgba(79, 70, 229, 0.15);
+        --shadow-soft: 0 20px 45px rgba(76, 29, 149, 0.08);
+        --radius-lg: 26px;
+        --radius-md: 18px;
+        --radius-sm: 12px;
+        --chart-baseline: #4338ca;
+        --chart-highlight: #f59e0b;
+        --chart-accent: #5b21b6;
+        --chart-muted: rgba(79, 70, 229, 0.28);
+        --chart-grid: rgba(79, 70, 229, 0.18);
+        --chart-axis: rgba(30, 41, 59, 0.72);
+        background-color: var(--bg-surface);
+      }
+
       body {
-        padding: 1.25rem;
+        margin: 0;
+        font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+        background: var(--bg-surface);
+        color: var(--ink-strong);
+        min-height: 100vh;
       }
-      main {
-        padding: 2rem 1.5rem;
+
+      body.theme-sepia {
+        --bg-surface: #f7f1e4;
+        --bg-panel: #fff9ef;
+        --bg-emphasis: #f2e2c8;
+        --bg-chip: rgba(190, 144, 63, 0.1);
+        --ink-strong: #432f16;
+        --ink-soft: rgba(67, 47, 22, 0.8);
+        --ink-subtle: rgba(67, 47, 22, 0.62);
+        --brand: #8b5d26;
+        --brand-strong: #6c4314;
+        --brand-soft: #b7791f;
+        --border-soft: rgba(139, 93, 38, 0.26);
+        --shadow-soft: 0 20px 45px rgba(108, 67, 20, 0.18);
+        --chart-baseline: #8c6239;
+        --chart-highlight: #d97706;
+        --chart-accent: #6c2a1c;
+        --chart-muted: rgba(140, 98, 57, 0.38);
+        --chart-grid: rgba(140, 98, 57, 0.22);
+        --chart-axis: rgba(72, 54, 32, 0.78);
       }
-      .control-grid {
-        grid-template-columns: 1fr;
-      }
-      .control-grid .value {
-        justify-self: flex-end;
-      }
-      .scenario-switch {
-        border-radius: 1.25rem;
-      }
-      .theme-toolbar {
+
+      .page {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 48px 32px 64px;
+        display: flex;
         flex-direction: column;
-        align-items: stretch;
+        gap: 48px;
       }
+
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 32px;
+      }
+
+      .brand {
+        display: flex;
+        gap: 20px;
+        align-items: center;
+      }
+
+      .brand img {
+        width: 140px;
+        height: auto;
+      }
+
+      .brand h1 {
+        margin: 0;
+        font-family: 'Poppins', 'Inter', sans-serif;
+        font-size: clamp(2rem, 3vw + 1rem, 3rem);
+        letter-spacing: -0.02em;
+      }
+
+      .brand p {
+        margin: 6px 0 0;
+        color: var(--ink-subtle);
+        max-width: 520px;
+        line-height: 1.5;
+      }
+
       .theme-toggle {
-        width: 100%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        border: none;
+        border-radius: 999px;
+        padding: 0.85rem 1.2rem;
+        background: var(--bg-chip);
+        color: var(--brand-strong);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
       }
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <header>
-      <img src="../img/ifp-logo.svg" alt="Institute for Progress logo">
-      <h1>The Wage Level Mirage: H-1B Policy Lab</h1>
-    </header>
-    <p class="lede">Experiment with DHS’s weighted lottery, pure compensation ranking, or custom hybrids to see how different rules reshape wages, visa allocation, and the innovation pipeline.</p>
 
-    <section class="narrative">
-      <h2>Why Wage Levels Mislead</h2>
-      <p>The Department of Homeland Security has floated a weighted lottery that gives more chances to workers certified at higher Department of Labor Wage Levels. The catch: Wage Levels track seniority within an occupation, not actual pay. Outsourcing firms often certify mid-career staff at Level III or IV while paying well below frontier salaries, whereas recent US STEM graduates are usually Level I even with six-figure offers.</p>
-      <p>Using FOIA-linked FY2021–FY2024 records, the lab below shows what happens when you prioritize Wage Levels, real compensation, or hybrids augmented with STEM boosts, outsourcer guardrails, and R&amp;D incentives.</p>
-    </section>
+      .theme-toggle:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 10px 18px rgba(91, 33, 182, 0.12);
+      }
 
-    <div class="h1b-lab" id="h1b-lab">
-      <div class="h1b-policy-controls">
-        <div class="theme-toolbar">
-          <div>
-            <p class="control-label">Visual theme</p>
-            <p class="control-help">Flip between modern policy visuals and a Civil War dispatch motif.</p>
-          </div>
-          <button type="button" id="theme-toggle" class="theme-toggle" aria-pressed="false">
-            <strong>Enter Civil War mode</strong>
-            <span>Sepia maps &amp; dispatch styling</span>
-          </button>
-        </div>
-        <h2>Design an allocation rule</h2>
-        <div class="control-stack">
-          <p class="control-label">Policy template</p>
-          <div class="scenario-switch" role="group" aria-label="Policy template">
-            <button type="button" data-scenario="wage" class="active" aria-pressed="true">
-              <strong>Weighted lottery</strong>
-              <span>DHS proposal</span>
-            </button>
-            <button type="button" data-scenario="statusquo" aria-pressed="false">
-              <strong>Random lottery</strong>
-              <span>Status quo baseline</span>
-            </button>
-            <button type="button" data-scenario="comp" aria-pressed="false">
-              <strong>Compensation ranking</strong>
-              <span>Pay-first selection</span>
-            </button>
-            <button type="button" data-scenario="hybrid" aria-pressed="false">
-              <strong>Build a hybrid</strong>
-              <span>Blend pay &amp; Wage Levels</span>
-            </button>
-          </div>
-        </div>
-        <div class="control-grid hybrid-row" id="hybrid-row" hidden>
-          <div>
-            <p class="control-label">Blend weight on actual compensation</p>
-            <p class="control-help">Slide toward 100% to mirror a pure compensation ranking.</p>
-          </div>
-          <input type="range" id="comp-weight" min="0" max="100" value="60" step="5">
-          <span class="value" id="comp-weight-value">60%</span>
-        </div>
-        <fieldset class="policy-toggles">
-          <legend>Layer on additional levers</legend>
-          <label><input type="checkbox" id="outsourcer-guardrails" checked> Impose outsourcer fee &amp; L-1 guardrails</label>
-          <label><input type="checkbox" id="stem-boost" checked> Priority for US STEM graduates</label>
-          <label><input type="checkbox" id="phd-credit"> R&amp;D credit for PhD-intensive employers</label>
-        </fieldset>
-      </div>
+      main {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
 
-      <div class="h1b-metrics">
-        <div class="metric-card">
-          <h4>Median salary</h4>
-          <p class="metric-value" id="metric-median">--</p>
-          <p class="metric-footnote">2024 petition median (thousands USD)</p>
-        </div>
-        <div class="metric-card">
-          <h4>Opportunity floor</h4>
-          <p class="metric-value" id="metric-p10">--</p>
-          <p class="metric-footnote">10th percentile salary in 2024</p>
-        </div>
-        <div class="metric-card">
-          <h4>Outsourcer share</h4>
-          <p class="metric-value" id="metric-outsourcers">--</p>
-          <p class="metric-footnote">Share of visas to large outsourcers</p>
-        </div>
-        <div class="metric-card">
-          <h4>Innovation index</h4>
-          <p class="metric-value" id="metric-innovation">--</p>
-          <p class="metric-footnote">Composite of wages, PhDs, and outsourcer shifts</p>
-        </div>
-        <div class="metric-card">
-          <h4>F-1 talent pipeline</h4>
-          <p class="metric-value" id="metric-f1">--</p>
-          <p class="metric-footnote">Share of visas to US-educated graduates</p>
-        </div>
-        <div class="metric-card">
-          <h4>PhD share</h4>
-          <p class="metric-value" id="metric-phd">--</p>
-          <p class="metric-footnote">Share of visas to PhD holders</p>
-        </div>
-      </div>
+      .control-panel {
+        position: sticky;
+        top: 0;
+        z-index: 4;
+        background: linear-gradient(var(--bg-panel), var(--bg-panel));
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-soft);
+        border: 1px solid var(--border-soft);
+        padding: 28px 32px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        backdrop-filter: blur(22px);
+      }
 
-      <div class="chart-card">
-        <h3>Wage outcomes under your rule</h3>
-        <svg id="wage-chart" viewBox="0 0 720 360" role="img" aria-labelledby="wage-chart-title wage-chart-desc">
-          <title id="wage-chart-title">Wage outcomes under your rule</title>
-          <desc id="wage-chart-desc">Line chart comparing the baseline status quo lottery with your selected rule for median wages and 10th percentile wages from 2021 to 2024.</desc>
-        </svg>
-      </div>
+      @media (max-width: 720px) {
+        .control-panel {
+          position: static;
+        }
+      }
 
-      <div class="chart-card">
-        <h3>Who receives visas in 2024</h3>
-        <svg id="share-chart" viewBox="0 0 720 280" role="img" aria-labelledby="share-chart-title share-chart-desc">
-          <title id="share-chart-title">Visa shares for key groups</title>
-          <desc id="share-chart-desc">Grouped horizontal bars comparing the status quo lottery with your selected rule for outsourcers, F-1 graduates, and PhD holders.</desc>
-        </svg>
-      </div>
+      .control-panel header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px 24px;
+        align-items: center;
+        justify-content: space-between;
+      }
 
-      <div class="chart-card">
-        <h3>Innovation &amp; productivity index</h3>
-        <svg id="productivity-chart" viewBox="0 0 720 320" role="img" aria-labelledby="productivity-chart-title productivity-chart-desc">
-          <title id="productivity-chart-title">Innovation index comparison</title>
-          <desc id="productivity-chart-desc">Scatter plot showing baseline and scenario innovation index versus 2024 median wages.</desc>
-        </svg>
-      </div>
+      .control-panel h2 {
+        margin: 0;
+        font-size: 1.1rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--ink-subtle);
+      }
 
-      <div id="h1b-summary" class="h1b-summary" aria-live="polite">
-        <h3>Scenario summary</h3>
-        <p class="control-help">Adjust the controls above to generate a narrative summary.</p>
-      </div>
-      <div id="h1b-campaign-log" class="h1b-campaign-log" aria-live="polite"></div>
+      .control-grid {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: repeat(2, minmax(260px, 1fr));
+        align-items: start;
+      }
 
-      <h3 class="lab-notes-heading">What the levers imply</h3>
-      <ul class="lab-notes">
-        <li><strong>Outsourcer guardrails</strong> apply a combination of targeted fees and tighter L-1 conversions, shaving 20% off large outsourcers’ visa capture and nudging wages higher as employers swap in higher-paying roles.</li>
-        <li><strong>STEM boost</strong> simulates a small reserved pool for US STEM graduates plus optional early filing flexibility, translating into a 1.5 percentage-point lift in F-1 share and a modest wage bump at the bottom.</li>
-        <li><strong>PhD credit</strong> mimics a research tax credit or points-based reserve focused on deep research teams. The lever boosts PhD selection by 25% but also pushes employers toward higher-salary offers to stay competitive.</li>
-      </ul>
-    </div>
-  </main>
+      @media (max-width: 1024px) {
+        .control-grid {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  <script>
-    (function() {
-      const lab = document.getElementById('h1b-lab');
-      const themeToggle = document.getElementById('theme-toggle');
-      const themeToggleText = themeToggle.querySelector('strong');
-      const themeToggleHint = themeToggle.querySelector('span');
-      const campaignLogEl = document.getElementById('h1b-campaign-log');
+      .control-group {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
 
-      const years = [2021, 2022, 2023, 2024];
+      .control-group h3 {
+        margin: 0;
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-subtle);
+      }
 
-      const scenarios = {
+      .control-panel p {
+        margin: 0;
+        color: var(--ink-soft);
+        line-height: 1.5;
+      }
+
+      .scenario-switch {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .scenario-button {
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        padding: 16px 20px;
+        text-align: left;
+        background: rgba(255, 255, 255, 0.7);
+        color: var(--ink-soft);
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        cursor: pointer;
+        min-width: clamp(220px, 24vw, 260px);
+        transition: border-color 150ms ease, background 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+      }
+
+      .scenario-button strong {
+        font-size: 1.05rem;
+        color: var(--ink-strong);
+        letter-spacing: -0.01em;
+      }
+
+      .scenario-button span {
+        font-size: 0.9rem;
+        line-height: 1.45;
+      }
+
+      .scenario-button.active {
+        border-color: var(--brand-soft);
+        background: linear-gradient(135deg, rgba(91, 33, 182, 0.12), rgba(79, 70, 229, 0.05));
+        transform: translateY(-2px);
+        box-shadow: 0 12px 26px rgba(91, 33, 182, 0.16);
+      }
+
+      .slider-group {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        padding: 18px 20px 22px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border-soft);
+        background: rgba(255, 255, 255, 0.7);
+      }
+
+      .slider-group p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--ink-subtle);
+      }
+
+      .slider-group header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .slider-group label {
+        font-weight: 600;
+        color: var(--ink-soft);
+      }
+
+      .slider-value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+        color: var(--brand-strong);
+      }
+
+      .slider-scale {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-subtle);
+      }
+
+      input[type='range'] {
+        appearance: none;
+        width: 100%;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, var(--brand-soft), rgba(91, 33, 182, 0.2));
+        outline: none;
+      }
+
+      input[type='range']::-webkit-slider-thumb {
+        appearance: none;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: var(--bg-panel);
+        border: 2px solid var(--brand-strong);
+        box-shadow: 0 4px 10px rgba(76, 29, 149, 0.2);
+        transition: transform 150ms ease;
+      }
+
+      input[type='range']::-webkit-slider-thumb:hover {
+        transform: scale(1.08);
+      }
+
+      input[type='range']::-moz-range-thumb {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: var(--bg-panel);
+        border: 2px solid var(--brand-strong);
+        box-shadow: 0 4px 10px rgba(76, 29, 149, 0.2);
+      }
+
+      .lever-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .lever-grid label {
+        display: inline-flex;
+        gap: 12px;
+        align-items: center;
+        padding: 12px 16px;
+        border-radius: 999px;
+        border: 1px solid var(--border-soft);
+        background: rgba(91, 33, 182, 0.08);
+        font-size: 0.95rem;
+        color: var(--brand-strong);
+        transition: border-color 150ms ease, background 150ms ease;
+      }
+
+      .lever-grid input[type='checkbox'] {
+        accent-color: var(--brand);
+        width: 18px;
+        height: 18px;
+      }
+
+      .lever-grid label:hover {
+        border-color: var(--brand-soft);
+        background: rgba(91, 33, 182, 0.12);
+      }
+
+      .content-column {
+        display: grid;
+        gap: 28px;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 20px;
+      }
+
+      .metric-card {
+        background: var(--bg-panel);
+        border-radius: var(--radius-md);
+        padding: 20px 22px;
+        border: 1px solid var(--border-soft);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .metric-card h3 {
+        margin: 0;
+        font-size: 0.8rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--ink-subtle);
+      }
+
+      .metric-card p {
+        margin: 12px 0 0;
+        font-size: 1.8rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+
+      .metric-card span {
+        display: block;
+        margin-top: 6px;
+        font-size: 0.88rem;
+        color: var(--ink-subtle);
+      }
+
+      .chart-card {
+        background: var(--bg-panel);
+        border-radius: var(--radius-lg);
+        padding: 24px 28px;
+        border: 1px solid var(--border-soft);
+        box-shadow: var(--shadow-soft);
+        display: grid;
+        gap: 12px;
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: 1.2rem;
+        font-weight: 600;
+      }
+
+      svg {
+        width: 100%;
+        height: auto;
+      }
+
+      .summary-card {
+        background: var(--bg-emphasis);
+        border-radius: var(--radius-lg);
+        padding: 28px;
+        display: grid;
+        gap: 16px;
+        line-height: 1.6;
+      }
+
+      .summary-card h3 {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .summary-card strong {
+        color: var(--brand-strong);
+      }
+
+      .log-card {
+        background: var(--bg-panel);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-soft);
+        padding: 24px 28px;
+        display: grid;
+        gap: 14px;
+      }
+
+      .log-card ul {
+        margin: 0;
+        padding-left: 20px;
+        color: var(--ink-soft);
+        line-height: 1.55;
+      }
+
+      footer {
+        padding: 0 32px 48px;
+        color: var(--ink-subtle);
+        text-align: center;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel">
+      const { useEffect, useMemo, useRef, useState } = React;
+
+      const YEARS = [2021, 2022, 2023, 2024];
+      const SCENARIO_DESCRIPTIONS = {
+        wage: 'Weighted lottery leans on DOL Wage Levels to reward higher posted salaries.',
+        statusquo: 'Random lottery mirrors the current two-stage draw without prioritization.',
+        comp: 'Actual compensation ranking elevates the true salary offers regardless of Wage Levels.',
+        hybrid: 'Blend Wage Level weighting with actual compensation to tune the emphasis.'
+      };
+
+      const SCENARIOS = {
         statusquo: {
+          id: 'statusquo',
           label: 'Status quo lottery',
           median: [88, 91, 93, 95],
           p10: [55, 58, 60, 62],
           outsourcerShare: [0.21, 0.2, 0.19, 0.19],
           f1Share: [0.18, 0.19, 0.19, 0.2],
-          phdShare: [0.09, 0.095, 0.1, 0.105]
+          phdShare: [0.09, 0.095, 0.1, 0.105],
+          caption: "Today's random selection without prioritization."
         },
         wage: {
+          id: 'wage',
           label: 'Weighted lottery (Wage Levels)',
           median: [90, 93, 95, 98],
           p10: [57, 60, 63, 70],
           outsourcerShare: [0.227, 0.216, 0.205, 0.205],
           f1Share: [0.167, 0.177, 0.177, 0.186],
-          phdShare: [0.11, 0.116, 0.122, 0.128]
+          phdShare: [0.11, 0.116, 0.122, 0.128],
+          caption: 'Boosts high Wage Level petitions while keeping the lottery structure.'
         },
         comp: {
+          id: 'comp',
           label: 'Compensation ranking (actual pay)',
           median: [130, 138, 145, 159],
           p10: [95, 110, 120, 130],
           outsourcerShare: [0.084, 0.081, 0.077, 0.075],
-          f1Share: [0.193, 0.203, 0.204, 0.214],
-          phdShare: [0.22, 0.235, 0.249, 0.26]
+          f1Share: [0.205, 0.215, 0.223, 0.236],
+          phdShare: [0.165, 0.174, 0.182, 0.194],
+          caption: 'Puts the highest salary offers first regardless of Wage Levels.'
         }
       };
 
-      const baseline = scenarios.statusquo;
-      const baselineLabel = baseline.label;
-
-      const hybridRow = document.getElementById('hybrid-row');
-      const compWeightSlider = document.getElementById('comp-weight');
-      const compWeightValue = document.getElementById('comp-weight-value');
-      const scenarioButtons = document.querySelectorAll('.scenario-switch button');
-      let currentPolicy = 'wage';
-
-      const outsourcerToggle = document.getElementById('outsourcer-guardrails');
-      const stemToggle = document.getElementById('stem-boost');
-      const phdToggle = document.getElementById('phd-credit');
-
-      const medianEl = document.getElementById('metric-median');
-      const p10El = document.getElementById('metric-p10');
-      const outsourcerEl = document.getElementById('metric-outsourcers');
-      const innovationEl = document.getElementById('metric-innovation');
-      const f1El = document.getElementById('metric-f1');
-      const phdEl = document.getElementById('metric-phd');
-      const summaryEl = document.getElementById('h1b-summary');
-
-      const wageChart = document.getElementById('wage-chart');
-      const shareChart = document.getElementById('share-chart');
-      const productivityChart = document.getElementById('productivity-chart');
-
-      const readThemePref = () => {
-        try {
-          return window.localStorage.getItem('h1bLabTheme');
-        } catch (error) {
-          return null;
-        }
-      };
-
-      const persistTheme = value => {
-        try {
-          window.localStorage.setItem('h1bLabTheme', value);
-        } catch (error) {
-          /* ignore storage failures */
-        }
-      };
-
-      function applyTheme(isCivilWar, persist = true) {
-        lab.classList.toggle('civil-war', isCivilWar);
-        document.body.classList.toggle('civil-war-canvas', isCivilWar);
-        themeToggle.setAttribute('aria-pressed', isCivilWar ? 'true' : 'false');
-        themeToggleText.textContent = isCivilWar ? 'Return to modern theme' : 'Enter Civil War mode';
-        themeToggleHint.textContent = isCivilWar ? 'Restore IFP purples & gradients' : 'Sepia maps & dispatch styling';
-        if (persist) {
-          persistTheme(isCivilWar ? 'civil-war' : 'modern');
-        }
-      }
-
-      applyTheme(readThemePref() === 'civil-war', false);
-
-      let colors = {};
-      function refreshColors() {
-        const styles = getComputedStyle(lab);
-        const read = (name, fallback) => {
-          const value = styles.getPropertyValue(name);
-          return (value && value.trim()) || fallback;
-        };
-        colors = {
-          baseline: read('--lab-chart-baseline', '#3f3d56'),
-          highlight: read('--lab-chart-highlight', '#5b21b6'),
-          accent: read('--lab-chart-accent', '#7c3aed'),
-          muted: read('--lab-chart-muted', 'rgba(63, 61, 86, 0.55)'),
-          axis: read('--lab-axis-color', 'rgba(36, 19, 54, 0.75)'),
-          axisStrong: read('--lab-axis-strong', 'rgba(36, 19, 54, 0.85)'),
-          axisLine: read('--lab-axis-line', '#cbd5f5'),
-          axisTick: read('--lab-axis-tick', '#94a3b8'),
-          grid: read('--lab-gridline', 'rgba(148, 163, 184, 0.25)'),
-          font: read('--lab-font', "'Inter', system-ui, sans-serif")
-        };
-      }
-
-      refreshColors();
+      const BASELINE = SCENARIOS.statusquo;
 
       function blendArrays(a, b, weight) {
-        return a.map((val, idx) => val + (b[idx] - val) * weight);
+        return a.map((value, index) => value + (b[index] - value) * weight);
       }
 
-      function applyToggles(metrics) {
+      function applyLevers(metrics, levers) {
         const adjusted = JSON.parse(JSON.stringify(metrics));
 
-        if (outsourcerToggle.checked) {
-          adjusted.outsourcerShare = adjusted.outsourcerShare.map(v => v * 0.8);
-          adjusted.median = adjusted.median.map(v => v + 2);
+        if (levers.outsourcer) {
+          adjusted.outsourcerShare = adjusted.outsourcerShare.map((value) => value * 0.8);
+          adjusted.median = adjusted.median.map((value) => value + 2);
         }
 
-        if (stemToggle.checked) {
-          adjusted.f1Share = adjusted.f1Share.map(v => Math.min(0.35, v + 0.015));
-          adjusted.median = adjusted.median.map(v => v + 1.5);
-          adjusted.p10 = adjusted.p10.map(v => v + 2);
+        if (levers.stem) {
+          adjusted.f1Share = adjusted.f1Share.map((value) => Math.min(0.35, value + 0.015));
+          adjusted.median = adjusted.median.map((value) => value + 1.5);
+          adjusted.p10 = adjusted.p10.map((value) => value + 2);
         }
 
-        if (phdToggle.checked) {
-          adjusted.phdShare = adjusted.phdShare.map(v => Math.min(0.4, v * 1.25));
-          adjusted.median = adjusted.median.map(v => v + 3);
+        if (levers.phd) {
+          adjusted.phdShare = adjusted.phdShare.map((value) => Math.min(0.4, value * 1.25));
+          adjusted.median = adjusted.median.map((value) => value + 3);
         }
 
         return adjusted;
       }
 
-      function getScenarioMetrics() {
-        let baseMetrics;
-
-        if (currentPolicy === 'hybrid') {
-          const weight = Number(compWeightSlider.value) / 100;
-          baseMetrics = {
-            label: `Hybrid weighting (${Math.round(weight * 100)}% compensation)`,
-            median: blendArrays(scenarios.wage.median, scenarios.comp.median, weight),
-            p10: blendArrays(scenarios.wage.p10, scenarios.comp.p10, weight),
-            outsourcerShare: blendArrays(scenarios.wage.outsourcerShare, scenarios.comp.outsourcerShare, weight),
-            f1Share: blendArrays(scenarios.wage.f1Share, scenarios.comp.f1Share, weight),
-            phdShare: blendArrays(scenarios.wage.phdShare, scenarios.comp.phdShare, weight)
-          };
-        } else {
-          baseMetrics = scenarios[currentPolicy];
-        }
-
-        const adjustedMetrics = applyToggles(baseMetrics);
-        adjustedMetrics.label = baseMetrics.label;
-        return adjustedMetrics;
-      }
-
       function computeIndex(metrics) {
-        const salaryFactor = metrics.median[3] / baseline.median[3];
-        const phdFactor = metrics.phdShare[3] / baseline.phdShare[3];
-        const outsourcerFactor = baseline.outsourcerShare[3] / metrics.outsourcerShare[3];
+        const salaryFactor = metrics.median[3] / BASELINE.median[3];
+        const phdFactor = metrics.phdShare[3] / BASELINE.phdShare[3];
+        const outsourcerFactor = BASELINE.outsourcerShare[3] / metrics.outsourcerShare[3];
         return Math.round(100 * (0.6 * salaryFactor + 0.25 * phdFactor + 0.15 * outsourcerFactor));
       }
 
       function computeGrowth(metrics) {
-        const wageLift = metrics.median.reduce((acc, val, idx) => acc + (val - baseline.median[idx]), 0);
-        const phdLift = metrics.phdShare.reduce((acc, val, idx) => acc + (val - baseline.phdShare[idx]), 0);
-        const outsourcerReduction = baseline.outsourcerShare.reduce((acc, val, idx) => acc + (val - metrics.outsourcerShare[idx]), 0);
-        return (wageLift * 0.4) + (phdLift * 250) + (outsourcerReduction * 120);
+        const wageLift = metrics.median.reduce((acc, value, index) => acc + (value - BASELINE.median[index]), 0);
+        const phdLift = metrics.phdShare.reduce((acc, value, index) => acc + (value - BASELINE.phdShare[index]), 0);
+        const outsourcerReduction = BASELINE.outsourcerShare.reduce(
+          (acc, value, index) => acc + (value - metrics.outsourcerShare[index]),
+          0
+        );
+        return wageLift * 0.4 + phdLift * 250 + outsourcerReduction * 120;
       }
 
-      const formatThousands = value => `$${Math.round(value)}k`;
-
-      function setTextStyle(node, fontFamily, color) {
-        node.setAttribute('font-family', fontFamily);
-        if (color) {
-          node.setAttribute('fill', color);
-        }
+      function readTokens() {
+        const styles = getComputedStyle(document.body);
+        const read = (name, fallback) => {
+          const raw = styles.getPropertyValue(name);
+          return (raw && raw.trim()) || fallback;
+        };
+        return {
+          baseline: read('--chart-baseline', '#4338ca'),
+          highlight: read('--chart-highlight', '#f59e0b'),
+          accent: read('--chart-accent', '#5b21b6'),
+          muted: read('--chart-muted', 'rgba(79, 70, 229, 0.28)'),
+          grid: read('--chart-grid', 'rgba(79, 70, 229, 0.18)'),
+          axis: read('--chart-axis', 'rgba(30, 41, 59, 0.72)'),
+          font: "'Inter', system-ui, sans-serif"
+        };
       }
 
       function createLinePath(points) {
-        return points.map((point, idx) => `${idx === 0 ? 'M' : 'L'}${point[0]} ${point[1]}`).join(' ');
+        return points.map((point, index) => `${index === 0 ? 'M' : 'L'}${point[0]} ${point[1]}`).join(' ');
       }
 
-      function drawWageChart(metrics, fontFamily) {
-        const viewBox = wageChart.getAttribute('viewBox').split(' ').map(Number);
-        const width = viewBox[2];
-        const height = viewBox[3];
-        const margin = { top: 40, right: 40, bottom: 60, left: 70 };
+      function drawWageChart(svg, metrics, tokens) {
+        if (!svg) return;
+        const viewBox = svg.getAttribute('viewBox').split(' ').map(Number);
+        const [width, height] = [viewBox[2], viewBox[3]];
+        const margin = { top: 32, right: 36, bottom: 52, left: 72 };
         const plotWidth = width - margin.left - margin.right;
         const plotHeight = height - margin.top - margin.bottom;
 
-        const values = [...baseline.median, ...metrics.median, ...metrics.p10];
-        const yMin = Math.min(...values) * 0.9;
+        const values = [...BASELINE.median, ...metrics.median, ...metrics.p10];
+        const yMin = Math.min(...values) * 0.92;
         const yMax = Math.max(...values) * 1.05;
+        const scaleX = (index) => margin.left + (plotWidth / (YEARS.length - 1)) * index;
+        const scaleY = (value) => margin.top + plotHeight - ((value - yMin) / (yMax - yMin)) * plotHeight;
 
-        const pointsX = years.map((_, idx) => margin.left + (plotWidth / (years.length - 1)) * idx);
-        const scaleY = value => margin.top + plotHeight - ((value - yMin) / (yMax - yMin)) * plotHeight;
-
-        wageChart.innerHTML = '';
+        svg.innerHTML = '';
 
         const axisGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        axisGroup.setAttribute('stroke', colors.axisLine);
+        axisGroup.setAttribute('stroke', tokens.grid);
         axisGroup.setAttribute('stroke-width', '1');
         axisGroup.innerHTML = `
           <line x1="${margin.left}" y1="${margin.top + plotHeight}" x2="${margin.left + plotWidth}" y2="${margin.top + plotHeight}" />
           <line x1="${margin.left}" y1="${margin.top}" x2="${margin.left}" y2="${margin.top + plotHeight}" />
         `;
-        wageChart.appendChild(axisGroup);
+        svg.appendChild(axisGroup);
 
         const ticks = 5;
-        for (let i = 0; i <= ticks; i++) {
+        for (let i = 0; i <= ticks; i += 1) {
           const value = yMin + ((yMax - yMin) / ticks) * i;
           const y = scaleY(value);
+
+          const grid = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          grid.setAttribute('x1', margin.left);
+          grid.setAttribute('x2', margin.left + plotWidth);
+          grid.setAttribute('y1', y);
+          grid.setAttribute('y2', y);
+          grid.setAttribute('stroke', tokens.grid);
+          grid.setAttribute('stroke-dasharray', '4 6');
+          svg.appendChild(grid);
+
           const tick = document.createElementNS('http://www.w3.org/2000/svg', 'line');
           tick.setAttribute('x1', margin.left - 6);
           tick.setAttribute('x2', margin.left);
           tick.setAttribute('y1', y);
           tick.setAttribute('y2', y);
-          tick.setAttribute('stroke', colors.axisTick);
-          wageChart.appendChild(tick);
+          tick.setAttribute('stroke', tokens.axis);
+          svg.appendChild(tick);
 
           const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
           label.setAttribute('x', margin.left - 12);
           label.setAttribute('y', y + 4);
           label.setAttribute('text-anchor', 'end');
           label.setAttribute('font-size', '12');
-          setTextStyle(label, fontFamily, colors.axis);
+          label.setAttribute('fill', tokens.axis);
+          label.setAttribute('font-family', tokens.font);
           label.textContent = `$${Math.round(value)}k`;
-          wageChart.appendChild(label);
-
-          const grid = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          grid.setAttribute('x1', margin.left);
-          grid.setAttribute('x2', margin.left + plotWidth);
-          grid.setAttribute('y1', y);
-          grid.setAttribute('y2', y);
-          grid.setAttribute('stroke', colors.grid);
-          wageChart.appendChild(grid);
+          svg.appendChild(label);
         }
 
-        years.forEach((year, idx) => {
-          const x = pointsX[idx];
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', x);
-          label.setAttribute('y', margin.top + plotHeight + 30);
-          label.setAttribute('text-anchor', 'middle');
-          label.setAttribute('font-size', '12');
-          setTextStyle(label, fontFamily, colors.axis);
-          label.textContent = year;
-          wageChart.appendChild(label);
+        YEARS.forEach((year, index) => {
+          const x = scaleX(index);
+          const tick = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          tick.setAttribute('x', x);
+          tick.setAttribute('y', margin.top + plotHeight + 30);
+          tick.setAttribute('text-anchor', 'middle');
+          tick.setAttribute('font-size', '12');
+          tick.setAttribute('fill', tokens.axis);
+          tick.setAttribute('font-family', tokens.font);
+          tick.textContent = year;
+          svg.appendChild(tick);
         });
 
-        const baselinePoints = baseline.median.map((val, idx) => [pointsX[idx], scaleY(val)]);
-        const scenarioPoints = metrics.median.map((val, idx) => [pointsX[idx], scaleY(val)]);
-        const p10Points = metrics.p10.map((val, idx) => [pointsX[idx], scaleY(val)]);
+        const basePoints = BASELINE.median.map((value, index) => [scaleX(index), scaleY(value)]);
+        const scenarioMedianPoints = metrics.median.map((value, index) => [scaleX(index), scaleY(value)]);
+        const scenarioP10Points = metrics.p10.map((value, index) => [scaleX(index), scaleY(value)]);
 
-        const baselinePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        baselinePath.setAttribute('d', createLinePath(baselinePoints));
-        baselinePath.setAttribute('fill', 'none');
-        baselinePath.setAttribute('stroke', colors.baseline);
-        baselinePath.setAttribute('stroke-width', '2');
-        baselinePath.setAttribute('stroke-dasharray', '6 4');
-        wageChart.appendChild(baselinePath);
+        const basePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        basePath.setAttribute('d', createLinePath(basePoints));
+        basePath.setAttribute('fill', 'none');
+        basePath.setAttribute('stroke', tokens.muted);
+        basePath.setAttribute('stroke-width', '3');
+        svg.appendChild(basePath);
 
-        const scenarioPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        scenarioPath.setAttribute('d', createLinePath(scenarioPoints));
-        scenarioPath.setAttribute('fill', 'none');
-        scenarioPath.setAttribute('stroke', colors.highlight);
-        scenarioPath.setAttribute('stroke-width', '3');
-        wageChart.appendChild(scenarioPath);
+        const medianPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        medianPath.setAttribute('d', createLinePath(scenarioMedianPoints));
+        medianPath.setAttribute('fill', 'none');
+        medianPath.setAttribute('stroke', tokens.accent);
+        medianPath.setAttribute('stroke-width', '4');
+        svg.appendChild(medianPath);
 
         const p10Path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        p10Path.setAttribute('d', createLinePath(p10Points));
+        p10Path.setAttribute('d', createLinePath(scenarioP10Points));
         p10Path.setAttribute('fill', 'none');
-        p10Path.setAttribute('stroke', colors.accent);
-        p10Path.setAttribute('stroke-width', '2');
-        p10Path.setAttribute('stroke-dasharray', '4 4');
-        wageChart.appendChild(p10Path);
-
-        const legend = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        legend.setAttribute('transform', `translate(${margin.left}, ${margin.top - 15})`);
-        const entries = [
-          { label: `${baselineLabel} median salary`, color: colors.baseline, dash: '6 4', width: 2 },
-          { label: `${metrics.label} median salary`, color: colors.highlight, dash: null, width: 3 },
-          { label: `${metrics.label} 10th percentile`, color: colors.accent, dash: '4 4', width: 2 }
-        ];
-        entries.forEach((entry, idx) => {
-          const yOffset = idx * 18;
-          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          line.setAttribute('x1', idx * 210);
-          line.setAttribute('x2', idx * 210 + 28);
-          line.setAttribute('y1', yOffset);
-          line.setAttribute('y2', yOffset);
-          line.setAttribute('stroke', entry.color);
-          line.setAttribute('stroke-width', entry.width);
-          if (entry.dash) {
-            line.setAttribute('stroke-dasharray', entry.dash);
-          }
-          legend.appendChild(line);
-
-          const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          text.setAttribute('x', idx * 210 + 36);
-          text.setAttribute('y', yOffset + 4);
-          text.setAttribute('font-size', '12');
-          setTextStyle(text, fontFamily, colors.axisStrong);
-          text.textContent = entry.label;
-          legend.appendChild(text);
-        });
-        wageChart.appendChild(legend);
+        p10Path.setAttribute('stroke', tokens.highlight);
+        p10Path.setAttribute('stroke-width', '3');
+        p10Path.setAttribute('stroke-dasharray', '8 6');
+        svg.appendChild(p10Path);
       }
 
-      function drawShareChart(metrics, fontFamily) {
-        const viewBox = shareChart.getAttribute('viewBox').split(' ').map(Number);
-        const width = viewBox[2];
-        const height = viewBox[3];
-        const margin = { top: 30, right: 40, bottom: 50, left: 190 };
+      function drawShareChart(svg, metrics, tokens) {
+        if (!svg) return;
+        const viewBox = svg.getAttribute('viewBox').split(' ').map(Number);
+        const [width, height] = [viewBox[2], viewBox[3]];
+        const margin = { top: 28, right: 40, bottom: 32, left: 160 };
         const plotWidth = width - margin.left - margin.right;
+        const rowHeight = (height - margin.top - margin.bottom) / 3;
 
-        const categories = ['Large outsourcers', 'F-1 graduates', 'PhD holders'];
-        const shareValues = [
-          metrics.outsourcerShare[3] * 100,
-          metrics.f1Share[3] * 100,
-          metrics.phdShare[3] * 100
-        ];
-        const shareBaseline = [
-          baseline.outsourcerShare[3] * 100,
-          baseline.f1Share[3] * 100,
-          baseline.phdShare[3] * 100
+        svg.innerHTML = '';
+
+        const groups = [
+          { label: 'Large outsourcers', base: BASELINE.outsourcerShare[3], scenario: metrics.outsourcerShare[3] },
+          { label: 'F-1 graduates', base: BASELINE.f1Share[3], scenario: metrics.f1Share[3] },
+          { label: 'PhD holders', base: BASELINE.phdShare[3], scenario: metrics.phdShare[3] }
         ];
 
-        const maxValue = Math.max(...shareValues, ...shareBaseline) * 1.15;
-        const scaleX = value => margin.left + (value / maxValue) * plotWidth;
+        const xMax = Math.max(...groups.map((group) => Math.max(group.base, group.scenario))) * 1.2;
 
-        shareChart.innerHTML = '';
+        groups.forEach((group, index) => {
+          const y = margin.top + index * rowHeight;
+          const baseWidth = (group.base / xMax) * plotWidth;
+          const scenarioWidth = (group.scenario / xMax) * plotWidth;
 
-        const axisLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-        axisLine.setAttribute('x1', margin.left);
-        axisLine.setAttribute('x2', margin.left + plotWidth);
-        axisLine.setAttribute('y1', height - margin.bottom);
-        axisLine.setAttribute('y2', height - margin.bottom);
-        axisLine.setAttribute('stroke', colors.axisLine);
-        shareChart.appendChild(axisLine);
+          const baseRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+          baseRect.setAttribute('x', margin.left);
+          baseRect.setAttribute('y', y + 12);
+          baseRect.setAttribute('width', baseWidth);
+          baseRect.setAttribute('height', rowHeight - 24);
+          baseRect.setAttribute('fill', tokens.muted);
+          baseRect.setAttribute('rx', 10);
+          svg.appendChild(baseRect);
 
-        const ticks = 5;
-        for (let i = 0; i <= ticks; i++) {
-          const value = (maxValue / ticks) * i;
-          const x = scaleX(value);
-          const tick = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          tick.setAttribute('x1', x);
-          tick.setAttribute('x2', x);
-          tick.setAttribute('y1', height - margin.bottom);
-          tick.setAttribute('y2', height - margin.bottom + 6);
-          tick.setAttribute('stroke', colors.axisTick);
-          shareChart.appendChild(tick);
-
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', x);
-          label.setAttribute('y', height - margin.bottom + 22);
-          label.setAttribute('font-size', '12');
-          label.setAttribute('text-anchor', 'middle');
-          setTextStyle(label, fontFamily, colors.axis);
-          label.textContent = `${value.toFixed(0)}%`;
-          shareChart.appendChild(label);
-        }
-
-        const barHeight = 18;
-        const barGap = 34;
-
-        categories.forEach((category, idx) => {
-          const yBase = margin.top + idx * (barHeight * 2 + barGap);
+          const scenarioRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+          scenarioRect.setAttribute('x', margin.left);
+          scenarioRect.setAttribute('y', y + 12);
+          scenarioRect.setAttribute('width', scenarioWidth);
+          scenarioRect.setAttribute('height', rowHeight - 24);
+          scenarioRect.setAttribute('fill', tokens.accent);
+          scenarioRect.setAttribute('rx', 10);
+          scenarioRect.setAttribute('opacity', '0.9');
+          svg.appendChild(scenarioRect);
 
           const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
           label.setAttribute('x', margin.left - 12);
-          label.setAttribute('y', yBase + barHeight);
-          label.setAttribute('font-size', '13');
+          label.setAttribute('y', y + rowHeight / 2 + 4);
           label.setAttribute('text-anchor', 'end');
-          setTextStyle(label, fontFamily, colors.axisStrong);
-          label.textContent = category;
-          shareChart.appendChild(label);
+          label.setAttribute('font-size', '14');
+          label.setAttribute('fill', tokens.axis);
+          label.setAttribute('font-family', tokens.font);
+          label.textContent = group.label;
+          svg.appendChild(label);
 
-          const baselineBar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          baselineBar.setAttribute('x', margin.left);
-          baselineBar.setAttribute('y', yBase);
-          baselineBar.setAttribute('height', barHeight);
-          baselineBar.setAttribute('width', Math.max(2, scaleX(shareBaseline[idx]) - margin.left));
-          baselineBar.setAttribute('fill', colors.muted);
-          shareChart.appendChild(baselineBar);
-
-          const scenarioBar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          scenarioBar.setAttribute('x', margin.left);
-          scenarioBar.setAttribute('y', yBase + barHeight + 6);
-          scenarioBar.setAttribute('height', barHeight);
-          scenarioBar.setAttribute('width', Math.max(2, scaleX(shareValues[idx]) - margin.left));
-          scenarioBar.setAttribute('fill', colors.highlight);
-          shareChart.appendChild(scenarioBar);
-
-          const baselineLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          baselineLabel.setAttribute('x', scaleX(shareBaseline[idx]) + 8);
-          baselineLabel.setAttribute('y', yBase + barHeight - 4);
-          baselineLabel.setAttribute('font-size', '11');
-          setTextStyle(baselineLabel, fontFamily, colors.axis);
-          baselineLabel.textContent = `${shareBaseline[idx].toFixed(1)}%`;
-          shareChart.appendChild(baselineLabel);
+          const baseLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          baseLabel.setAttribute('x', margin.left + baseWidth + 12);
+          baseLabel.setAttribute('y', y + rowHeight / 2 - 2);
+          baseLabel.setAttribute('font-size', '12');
+          baseLabel.setAttribute('fill', tokens.axis);
+          baseLabel.setAttribute('font-family', tokens.font);
+          baseLabel.textContent = `${(group.base * 100).toFixed(1)}% baseline`;
+          svg.appendChild(baseLabel);
 
           const scenarioLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          scenarioLabel.setAttribute('x', scaleX(shareValues[idx]) + 8);
-          scenarioLabel.setAttribute('y', yBase + barHeight * 2 + 2);
-          scenarioLabel.setAttribute('font-size', '11');
-          setTextStyle(scenarioLabel, fontFamily, colors.axisStrong);
-          scenarioLabel.textContent = `${shareValues[idx].toFixed(1)}%`;
-          shareChart.appendChild(scenarioLabel);
+          scenarioLabel.setAttribute('x', margin.left + scenarioWidth + 12);
+          scenarioLabel.setAttribute('y', y + rowHeight / 2 + 14);
+          scenarioLabel.setAttribute('font-size', '12');
+          scenarioLabel.setAttribute('fill', tokens.accent);
+          scenarioLabel.setAttribute('font-family', tokens.font);
+          scenarioLabel.textContent = `${(group.scenario * 100).toFixed(1)}% scenario`;
+          svg.appendChild(scenarioLabel);
         });
-
-        const legend = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        legend.setAttribute('transform', `translate(${margin.left}, ${height - margin.bottom - 40})`);
-        const legendData = [
-          { label: baselineLabel, color: colors.muted },
-          { label: metrics.label, color: colors.highlight }
-        ];
-        legendData.forEach((item, idx) => {
-          const xOffset = idx * 160;
-          const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          rect.setAttribute('x', xOffset);
-          rect.setAttribute('y', 0);
-          rect.setAttribute('width', 18);
-          rect.setAttribute('height', 18);
-          rect.setAttribute('fill', item.color);
-          legend.appendChild(rect);
-
-          const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          text.setAttribute('x', xOffset + 26);
-          text.setAttribute('y', 14);
-          text.setAttribute('font-size', '12');
-          setTextStyle(text, fontFamily, colors.axisStrong);
-          text.textContent = item.label;
-          legend.appendChild(text);
-        });
-        shareChart.appendChild(legend);
       }
 
-      function drawProductivityChart(metrics, indexScore, fontFamily) {
-        const viewBox = productivityChart.getAttribute('viewBox').split(' ').map(Number);
-        const width = viewBox[2];
-        const height = viewBox[3];
-        const margin = { top: 30, right: 30, bottom: 60, left: 90 };
+      function drawProductivityChart(svg, metrics, indexScore, tokens) {
+        if (!svg) return;
+        const viewBox = svg.getAttribute('viewBox').split(' ').map(Number);
+        const [width, height] = [viewBox[2], viewBox[3]];
+        const margin = { top: 36, right: 32, bottom: 48, left: 70 };
         const plotWidth = width - margin.left - margin.right;
         const plotHeight = height - margin.top - margin.bottom;
 
-        const xValues = [baseline.median[3], metrics.median[3]];
+        const xValues = [BASELINE.median[3], metrics.median[3]];
         const yValues = [100, indexScore];
-
         const xMin = Math.min(...xValues) * 0.95;
         const xMax = Math.max(...xValues) * 1.05;
-        const yMin = Math.min(...yValues) - 5;
-        const yMax = Math.max(...yValues) + 10;
+        const yMin = Math.min(...yValues) * 0.94;
+        const yMax = Math.max(...yValues) * 1.06;
 
-        const scaleX = value => margin.left + ((value - xMin) / (xMax - xMin)) * plotWidth;
-        const scaleY = value => margin.top + plotHeight - ((value - yMin) / (yMax - yMin)) * plotHeight;
+        const scaleX = (value) => margin.left + ((value - xMin) / (xMax - xMin)) * plotWidth;
+        const scaleY = (value) => margin.top + plotHeight - ((value - yMin) / (yMax - yMin)) * plotHeight;
 
-        productivityChart.innerHTML = '';
+        svg.innerHTML = '';
 
-        const axes = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        axes.innerHTML = `
-          <line x1="${margin.left}" y1="${margin.top + plotHeight}" x2="${margin.left + plotWidth}" y2="${margin.top + plotHeight}" stroke="${colors.axisLine}" />
-          <line x1="${margin.left}" y1="${margin.top}" x2="${margin.left}" y2="${margin.top + plotHeight}" stroke="${colors.axisLine}" />
-        `;
-        productivityChart.appendChild(axes);
+        const axisX = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        axisX.setAttribute('x1', margin.left);
+        axisX.setAttribute('x2', margin.left + plotWidth);
+        axisX.setAttribute('y1', margin.top + plotHeight);
+        axisX.setAttribute('y2', margin.top + plotHeight);
+        axisX.setAttribute('stroke', tokens.grid);
+        svg.appendChild(axisX);
 
-        const yTicks = 4;
-        for (let i = 0; i <= yTicks; i++) {
-          const value = yMin + ((yMax - yMin) / yTicks) * i;
+        const axisY = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        axisY.setAttribute('x1', margin.left);
+        axisY.setAttribute('x2', margin.left);
+        axisY.setAttribute('y1', margin.top);
+        axisY.setAttribute('y2', margin.top + plotHeight);
+        axisY.setAttribute('stroke', tokens.grid);
+        svg.appendChild(axisY);
+
+        [BASELINE.median[3], metrics.median[3]].forEach((value) => {
+          const x = scaleX(value);
+          const grid = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          grid.setAttribute('x1', x);
+          grid.setAttribute('x2', x);
+          grid.setAttribute('y1', margin.top);
+          grid.setAttribute('y2', margin.top + plotHeight);
+          grid.setAttribute('stroke', tokens.grid);
+          grid.setAttribute('stroke-dasharray', '6 6');
+          svg.appendChild(grid);
+        });
+
+        [100, indexScore].forEach((value) => {
           const y = scaleY(value);
-          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          line.setAttribute('x1', margin.left - 6);
-          line.setAttribute('x2', margin.left);
-          line.setAttribute('y1', y);
-          line.setAttribute('y2', y);
-          line.setAttribute('stroke', colors.axisTick);
-          productivityChart.appendChild(line);
-
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', margin.left - 10);
-          label.setAttribute('y', y + 4);
-          label.setAttribute('text-anchor', 'end');
-          label.setAttribute('font-size', '12');
-          setTextStyle(label, fontFamily, colors.axis);
-          label.textContent = Math.round(value);
-          productivityChart.appendChild(label);
-
           const grid = document.createElementNS('http://www.w3.org/2000/svg', 'line');
           grid.setAttribute('x1', margin.left);
           grid.setAttribute('x2', margin.left + plotWidth);
           grid.setAttribute('y1', y);
           grid.setAttribute('y2', y);
-          grid.setAttribute('stroke', colors.grid);
-          productivityChart.appendChild(grid);
-        }
+          grid.setAttribute('stroke', tokens.grid);
+          grid.setAttribute('stroke-dasharray', '6 6');
+          svg.appendChild(grid);
+        });
 
-        const xTicks = 4;
-        for (let i = 0; i <= xTicks; i++) {
-          const value = xMin + ((xMax - xMin) / xTicks) * i;
-          const x = scaleX(value);
-          const tick = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          tick.setAttribute('x1', x);
-          tick.setAttribute('x2', x);
-          tick.setAttribute('y1', margin.top + plotHeight);
-          tick.setAttribute('y2', margin.top + plotHeight + 6);
-          tick.setAttribute('stroke', colors.axisTick);
-          productivityChart.appendChild(tick);
+        const baselineCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        baselineCircle.setAttribute('cx', scaleX(BASELINE.median[3]));
+        baselineCircle.setAttribute('cy', scaleY(100));
+        baselineCircle.setAttribute('r', 12);
+        baselineCircle.setAttribute('fill', tokens.muted);
+        svg.appendChild(baselineCircle);
 
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', x);
-          label.setAttribute('y', margin.top + plotHeight + 24);
-          label.setAttribute('text-anchor', 'middle');
-          label.setAttribute('font-size', '12');
-          setTextStyle(label, fontFamily, colors.axis);
-          label.textContent = `$${Math.round(value)}k`;
-          productivityChart.appendChild(label);
-        }
+        const scenarioCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        scenarioCircle.setAttribute('cx', scaleX(metrics.median[3]));
+        scenarioCircle.setAttribute('cy', scaleY(indexScore));
+        scenarioCircle.setAttribute('r', 14);
+        scenarioCircle.setAttribute('fill', tokens.accent);
+        scenarioCircle.setAttribute('fill-opacity', '0.9');
+        scenarioCircle.setAttribute('stroke', '#ffffff');
+        scenarioCircle.setAttribute('stroke-width', '2');
+        svg.appendChild(scenarioCircle);
 
-        const points = [
-          { label: baselineLabel, x: baseline.median[3], y: 100, color: colors.muted },
-          { label: metrics.label, x: metrics.median[3], y: indexScore, color: colors.highlight }
+        const baseLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        baseLabel.setAttribute('x', scaleX(BASELINE.median[3]));
+        baseLabel.setAttribute('y', scaleY(100) + 28);
+        baseLabel.setAttribute('text-anchor', 'middle');
+        baseLabel.setAttribute('font-size', '12');
+        baseLabel.setAttribute('fill', tokens.axis);
+        baseLabel.setAttribute('font-family', tokens.font);
+        baseLabel.textContent = `Baseline · $${BASELINE.median[3]}k · 100 index`;
+        svg.appendChild(baseLabel);
+
+        const scenarioLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        scenarioLabel.setAttribute('x', scaleX(metrics.median[3]));
+        scenarioLabel.setAttribute('y', scaleY(indexScore) - 20);
+        scenarioLabel.setAttribute('text-anchor', 'middle');
+        scenarioLabel.setAttribute('font-size', '13');
+        scenarioLabel.setAttribute('fill', tokens.accent);
+        scenarioLabel.setAttribute('font-family', tokens.font);
+        scenarioLabel.textContent = `${metrics.label || 'Scenario'} · $${Math.round(metrics.median[3])}k · ${indexScore}`;
+        svg.appendChild(scenarioLabel);
+      }
+
+      function MetricCard({ title, value, detail }) {
+        return (
+          <article className="metric-card">
+            <h3>{title}</h3>
+            <p>{value}</p>
+            <span>{detail}</span>
+          </article>
+        );
+      }
+
+      function ScenarioButton({ id, label, caption, active, onClick }) {
+        return (
+          <button
+            type="button"
+            className={`scenario-button${active ? ' active' : ''}`}
+            aria-pressed={active}
+            onClick={() => onClick(id)}
+          >
+            <strong>{label}</strong>
+            <span>{caption}</span>
+          </button>
+        );
+      }
+
+      function useStoredTheme() {
+        const read = () => {
+          try {
+            return window.localStorage.getItem('ifp-theme') === 'sepia';
+          } catch (error) {
+            return false;
+          }
+        };
+
+        const [isSepia, setIsSepia] = useState(read);
+
+        useEffect(() => {
+          document.body.classList.toggle('theme-sepia', isSepia);
+          try {
+            window.localStorage.setItem('ifp-theme', isSepia ? 'sepia' : 'modern');
+          } catch (error) {
+            /* ignore */
+          }
+        }, [isSepia]);
+
+        return [isSepia, setIsSepia];
+      }
+
+      function App() {
+        const [policy, setPolicy] = useState('wage');
+        const [compWeight, setCompWeight] = useState(60);
+        const [levers, setLevers] = useState({ outsourcer: true, stem: true, phd: false });
+        const [isSepia, setIsSepia] = useStoredTheme();
+
+        const tokens = useMemo(readTokens, [isSepia]);
+
+        const metrics = useMemo(() => {
+          if (policy === 'hybrid') {
+            const weight = compWeight / 100;
+            const hybridMetrics = {
+              label: `Hybrid weighting (${compWeight}% compensation)`,
+              median: blendArrays(SCENARIOS.wage.median, SCENARIOS.comp.median, weight),
+              p10: blendArrays(SCENARIOS.wage.p10, SCENARIOS.comp.p10, weight),
+              outsourcerShare: blendArrays(
+                SCENARIOS.wage.outsourcerShare,
+                SCENARIOS.comp.outsourcerShare,
+                weight
+              ),
+              f1Share: blendArrays(SCENARIOS.wage.f1Share, SCENARIOS.comp.f1Share, weight),
+              phdShare: blendArrays(SCENARIOS.wage.phdShare, SCENARIOS.comp.phdShare, weight)
+            };
+            return applyLevers(hybridMetrics, levers);
+          }
+
+          const base = applyLevers(SCENARIOS[policy], levers);
+          return { ...base, label: SCENARIOS[policy].label };
+        }, [policy, compWeight, levers]);
+
+        const indexScore = useMemo(() => computeIndex(metrics), [metrics]);
+        const growthScore = useMemo(() => computeGrowth(metrics), [metrics]);
+
+        const summary = useMemo(() => {
+          const outsourcerPct = (metrics.outsourcerShare[3] * 100).toFixed(1);
+          const outsourcerDelta = ((metrics.outsourcerShare[3] / BASELINE.outsourcerShare[3] - 1) * 100).toFixed(1);
+          const f1Pct = (metrics.f1Share[3] * 100).toFixed(1);
+          const phdPct = (metrics.phdShare[3] * 100).toFixed(1);
+          const wageDelta = Math.round(metrics.median[3] - BASELINE.median[3]);
+          const floorDelta = Math.round(metrics.p10[3] - BASELINE.p10[3]);
+          const growthText =
+            growthScore >= 0
+              ? `adds ${(growthScore / 10).toFixed(1)} points to a national productivity composite`
+              : `subtracts ${(Math.abs(growthScore) / 10).toFixed(1)} points from a national productivity composite`;
+
+          return (
+            <>
+              <h3>{metrics.label || 'Scenario summary'}</h3>
+              <p>
+                Compared with today&apos;s random lottery, this rule lifts the innovation index to <strong>{indexScore}</strong>.
+                Median salaries reach <strong>${Math.round(metrics.median[3])}k</strong>,
+                {' '}
+                {wageDelta >= 0 ? 'up' : 'down'} {Math.abs(wageDelta)}k from the status quo, while the wage floor at the 10th
+                percentile sits at <strong>${Math.round(metrics.p10[3])}k</strong>{' '}
+                ({floorDelta >= 0 ? '+' : '-'}{Math.abs(floorDelta)}k).
+              </p>
+              <p>
+                Outsourcers now hold <strong>{outsourcerPct}%</strong> of visas ({outsourcerDelta >= 0 ? '+' : ''}
+                {outsourcerDelta}% shift), US-educated F-1 graduates capture <strong>{f1Pct}%</strong>, and PhD holders
+                represent <strong>{phdPct}%</strong> of awards. Overall this mix {growthText}.
+              </p>
+            </>
+          );
+        }, [metrics, indexScore, growthScore]);
+
+        const leverLog = useMemo(() => {
+          const entries = [];
+          entries.push(SCENARIO_DESCRIPTIONS[policy]);
+          if (policy === 'hybrid') {
+            entries.push(`Hybrid slider fixed at ${compWeight}% emphasis on actual compensation.`);
+          }
+          if (levers.outsourcer) {
+            entries.push('Outsourcer guardrails trim large outsourcer wins by roughly 20% before redistribution.');
+          }
+          if (levers.stem) {
+            entries.push('STEM boost reserves room for US-trained graduates, lifting F-1 share by about 1.5 points.');
+          }
+          if (levers.phd) {
+            entries.push('PhD credit rewards research-heavy teams with a 25% lift in doctoral selections.');
+          }
+          if (!levers.outsourcer && !levers.stem && !levers.phd) {
+            entries.push('No supplemental levers engaged—results flow entirely from your base template.');
+          }
+          if (isSepia) {
+            entries.push('Heritage mode active: sepia palette and archival typography.');
+          }
+          return entries;
+        }, [policy, compWeight, levers, isSepia]);
+
+        const sliderNarrative = useMemo(() => {
+          if (compWeight <= 30) {
+            return 'Prioritizes wage-ranking signals, keeping the lottery closer to today\'s prevailing wage tables.';
+          }
+          if (compWeight >= 70) {
+            return 'Leans into real compensation data so premium offers surge to the front of the line.';
+          }
+          return 'Balances wage tables with actual compensation to smooth volatility between sectors.';
+        }, [compWeight]);
+
+        const wageChartRef = useRef(null);
+        const shareChartRef = useRef(null);
+        const productivityChartRef = useRef(null);
+
+        useEffect(() => {
+          drawWageChart(wageChartRef.current, metrics, tokens);
+          drawShareChart(shareChartRef.current, metrics, tokens);
+          drawProductivityChart(productivityChartRef.current, metrics, indexScore, tokens);
+        }, [metrics, tokens, indexScore]);
+
+        const metricCards = [
+          {
+            title: 'Median salary',
+            value: `$${Math.round(metrics.median[3])}k`,
+            detail: 'Petition median in 2024'
+          },
+          {
+            title: 'Opportunity floor',
+            value: `$${Math.round(metrics.p10[3])}k`,
+            detail: '10th percentile salary in 2024'
+          },
+          {
+            title: 'Outsourcer share',
+            value: `${(metrics.outsourcerShare[3] * 100).toFixed(1)}%`,
+            detail: 'Share of visas to large outsourcers'
+          },
+          {
+            title: 'Innovation index',
+            value: `${indexScore}`,
+            detail: 'Composite of wages, PhDs, and outsourcer shifts'
+          },
+          {
+            title: 'F-1 talent pipeline',
+            value: `${(metrics.f1Share[3] * 100).toFixed(1)}%`,
+            detail: 'Share of visas to US-educated graduates'
+          },
+          {
+            title: 'PhD share',
+            value: `${(metrics.phdShare[3] * 100).toFixed(1)}%`,
+            detail: 'Share of visas to PhD holders'
+          }
         ];
 
-        points.forEach(point => {
-          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-          circle.setAttribute('cx', scaleX(point.x));
-          circle.setAttribute('cy', scaleY(point.y));
-          circle.setAttribute('r', point.label === baselineLabel ? 12 : 14);
-          circle.setAttribute('fill', point.color);
-          circle.setAttribute('fill-opacity', point.label === baselineLabel ? '0.85' : '1');
-          circle.setAttribute('stroke', colors.axisStrong);
-          circle.setAttribute('stroke-width', '1');
-          productivityChart.appendChild(circle);
+        const leverOptions = [
+          { id: 'outsourcer', label: 'Impose outsourcer fee & L-1 guardrails' },
+          { id: 'stem', label: 'Priority for US STEM graduates' },
+          { id: 'phd', label: 'R&D credit for PhD-intensive employers' }
+        ];
 
-          const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          text.setAttribute('x', scaleX(point.x));
-          text.setAttribute('y', scaleY(point.y) - (point.label === baselineLabel ? 18 : 20));
-          text.setAttribute('text-anchor', 'middle');
-          text.setAttribute('font-size', '12');
-          setTextStyle(text, fontFamily, colors.axisStrong);
-          text.textContent = `${point.label}: ${Math.round(point.y)}`;
-          productivityChart.appendChild(text);
-        });
+        const scenarioOptions = [
+          { id: 'wage', label: SCENARIOS.wage.label, caption: SCENARIOS.wage.caption },
+          { id: 'statusquo', label: SCENARIOS.statusquo.label, caption: SCENARIOS.statusquo.caption },
+          { id: 'comp', label: SCENARIOS.comp.label, caption: SCENARIOS.comp.caption },
+          { id: 'hybrid', label: 'Hybrid weighting', caption: 'Blend Wage Levels with true pay using the slider.' }
+        ];
+
+        return (
+          <>
+            <div className="page">
+            <header>
+              <div className="brand">
+                <img src="assets/ifp-logo.svg" alt="IFP logo" />
+                <div>
+                  <h1>H-1B Policy Lab</h1>
+                  <p>
+                    Explore how different immigration rules shift the talent mix, wage floor, and innovation index for the H-1B
+                    program. Toggle the levers to see who benefits and how outcomes evolve.
+                  </p>
+                </div>
+              </div>
+              <button className="theme-toggle" type="button" onClick={() => setIsSepia((value) => !value)}>
+                <span aria-hidden="true">🎞️</span>
+                <span>{isSepia ? 'Return to modern mode' : 'Enter heritage mode'}</span>
+              </button>
+            </header>
+
+            <main>
+              <section className="control-panel" aria-label="Scenario controls">
+                <header>
+                  <h2>Adjust the rule set</h2>
+                  <p>{SCENARIO_DESCRIPTIONS[policy]}</p>
+                </header>
+
+                <div className="control-grid">
+                  <div className="control-group">
+                    <h3>Choose a template</h3>
+                    <section className="scenario-switch" role="radiogroup" aria-label="Select a policy template">
+                      {scenarioOptions.map((option) => (
+                        <ScenarioButton
+                          key={option.id}
+                          id={option.id}
+                          label={option.label}
+                          caption={option.caption}
+                          active={policy === option.id}
+                          onClick={(value) => setPolicy(value)}
+                        />
+                      ))}
+                    </section>
+                  </div>
+
+                  <div className="control-group">
+                    <h3>Fine-tune levers</h3>
+                    {policy === 'hybrid' && (
+                      <div className="slider-group" role="group" aria-labelledby="comp-weight-label">
+                        <header>
+                          <label id="comp-weight-label" htmlFor="comp-weight">
+                            Hybrid emphasis on actual compensation
+                          </label>
+                          <span className="slider-value" aria-live="polite">
+                            {compWeight}%
+                          </span>
+                        </header>
+                        <input
+                          id="comp-weight"
+                          type="range"
+                          min="0"
+                          max="100"
+                          step="5"
+                          value={compWeight}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-valuenow={compWeight}
+                          aria-valuetext={`${compWeight}% emphasis on compensation`}
+                          aria-describedby="comp-weight-helper"
+                          onChange={(event) => setCompWeight(Number(event.target.value))}
+                        />
+                        <div className="slider-scale" aria-hidden="true">
+                          <span>0%</span>
+                          <span>50%</span>
+                          <span>100%</span>
+                        </div>
+                        <p id="comp-weight-helper">{sliderNarrative}</p>
+                      </div>
+                    )}
+
+                    <div className="lever-grid" role="group" aria-label="Activate policy levers">
+                      {leverOptions.map((lever) => (
+                        <label key={lever.id} htmlFor={`lever-${lever.id}`}>
+                          <input
+                            id={`lever-${lever.id}`}
+                            type="checkbox"
+                            checked={levers[lever.id]}
+                            onChange={(event) =>
+                              setLevers((current) => ({ ...current, [lever.id]: event.target.checked }))
+                            }
+                          />
+                          {lever.label}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div className="content-column">
+                <section className="metric-grid" aria-label="Key outcome metrics">
+                  {metricCards.map((card) => (
+                    <MetricCard key={card.title} {...card} />
+                  ))}
+                </section>
+
+                <section className="chart-card">
+                  <h3>Wage outcomes across time</h3>
+                  <svg ref={wageChartRef} viewBox="0 0 720 360" role="img" aria-labelledby="wage-chart-title wage-chart-desc">
+                    <title id="wage-chart-title">Median and 10th percentile salaries, 2021–2024</title>
+                    <desc id="wage-chart-desc">Line chart comparing the baseline lottery against the selected policy.</desc>
+                  </svg>
+                </section>
+
+                <section className="chart-card">
+                  <h3>Who receives visas in 2024</h3>
+                  <svg ref={shareChartRef} viewBox="0 0 720 280" role="img" aria-labelledby="share-chart-title share-chart-desc">
+                    <title id="share-chart-title">Share of visas for outsourcers, F-1 graduates, and PhDs</title>
+                    <desc id="share-chart-desc">Horizontal bars comparing the baseline lottery against the selected policy.</desc>
+                  </svg>
+                </section>
+
+                <section className="chart-card">
+                  <h3>Innovation &amp; productivity index</h3>
+                  <svg
+                    ref={productivityChartRef}
+                    viewBox="0 0 720 320"
+                    role="img"
+                    aria-labelledby="productivity-chart-title productivity-chart-desc"
+                  >
+                    <title id="productivity-chart-title">Innovation index versus median wage</title>
+                    <desc id="productivity-chart-desc">Scatter plot comparing baseline and selected policy outcomes.</desc>
+                  </svg>
+                </section>
+
+                <section className="summary-card" aria-live="polite">
+                  {summary}
+                </section>
+
+                <section className="log-card" aria-live="polite">
+                  <h3 style={{ margin: 0 }}>Lever log</h3>
+                  <ul>
+                    {leverLog.map((item, index) => (
+                      <li key={index}>{item}</li>
+                    ))}
+                  </ul>
+                </section>
+              </div>
+            </main>
+          </div>
+          <footer>
+            Updated in React for a cleaner, more legible exploration of H-1B policy scenarios.
+          </footer>
+          </>
+        );
       }
 
-      function updateLab() {
-        refreshColors();
-        const styles = getComputedStyle(lab);
-        const fontFamily = (styles.getPropertyValue('--lab-font') || '').trim() || colors.font;
-        [wageChart, shareChart, productivityChart].forEach(svg => { svg.style.fontFamily = fontFamily; });
-
-        const metrics = getScenarioMetrics();
-        const indexScore = computeIndex(metrics);
-        const growthScore = computeGrowth(metrics);
-
-        medianEl.textContent = formatThousands(metrics.median[3]);
-        p10El.textContent = formatThousands(metrics.p10[3]);
-
-        const outsourcerRatio = metrics.outsourcerShare[3] / baseline.outsourcerShare[3];
-        const outsourcerPct = (metrics.outsourcerShare[3] * 100).toFixed(1);
-        const outsourcerDelta = Number(((outsourcerRatio - 1) * 100).toFixed(1));
-        outsourcerEl.textContent = `${outsourcerPct}% (${outsourcerDelta >= 0 ? '+' : ''}${outsourcerDelta.toFixed(1)}%)`;
-
-        innovationEl.textContent = `${indexScore}`;
-        f1El.textContent = `${(metrics.f1Share[3] * 100).toFixed(1)}%`;
-        phdEl.textContent = `${(metrics.phdShare[3] * 100).toFixed(1)}%`;
-
-        drawWageChart(metrics, fontFamily);
-        drawShareChart(metrics, fontFamily);
-        drawProductivityChart(metrics, indexScore, fontFamily);
-
-        const growthText = growthScore >= 0
-          ? `adds an estimated ${(growthScore / 10).toFixed(1)} points to a national productivity composite`
-          : `reduces a national productivity composite by ${Math.abs(growthScore / 10).toFixed(1)} points`;
-
-        summaryEl.innerHTML = `
-          <h3>${metrics.label}</h3>
-          <p class="control-help" style="margin-bottom: 0.75rem;">Compared with ${baselineLabel.toLowerCase()}, here’s how this rule performs.</p>
-          <p>Your configuration lifts the innovation index to <strong>${indexScore}</strong>, ${indexScore >= 100 ? 'outpacing' : 'trailing'} today’s random lottery. Median wages reach <strong>${formatThousands(metrics.median[3])}</strong>, while the 10th percentile rises to <strong>${formatThousands(metrics.p10[3])}</strong>. F-1 graduates capture <strong>${(metrics.f1Share[3] * 100).toFixed(1)}%</strong> of visas and PhDs represent <strong>${(metrics.phdShare[3] * 100).toFixed(1)}%</strong>. Compared with the status quo, outsourcers ${outsourcerDelta >= 0 ? 'expand' : 'lose'} their footprint by <strong>${Math.abs(outsourcerDelta).toFixed(1)}%</strong>, and your mix ${growthText}.`;
-
-        const logItems = [];
-        const baseLine = {
-          wage: 'Weighted lottery leans on DOL Wage Levels to hand out extra entries.',
-          statusquo: 'Random lottery mirrors today’s two-stage draw with no prioritization.',
-          comp: 'Compensation ranking elevates the highest salary offers regardless of Wage Levels.',
-          hybrid: `Hybrid weighting locks in <strong>${compWeightSlider.value}%</strong> emphasis on actual pay.`
-        }[currentPolicy];
-        if (baseLine) {
-          logItems.push(baseLine);
-        }
-
-        if (outsourcerToggle.checked) {
-          logItems.push('Outsourcer guardrails trim large outsourcer wins by roughly <strong>20%</strong> before redistribution.');
-        }
-        if (stemToggle.checked) {
-          logItems.push('STEM boost reserves room for US-trained graduates, adding about <strong>1.5 points</strong> to their share.');
-        }
-        if (phdToggle.checked) {
-          logItems.push('PhD credit rewards research-heavy teams with a <strong>25%</strong> lift in doctoral selections.');
-        }
-        if (!outsourcerToggle.checked && !stemToggle.checked && !phdToggle.checked) {
-          logItems.push('No supplemental levers engaged—results flow entirely from your base template.');
-        }
-        if (lab.classList.contains('civil-war')) {
-          logItems.push('Civil War mode is active for sepia-toned visuals and period typography.');
-        }
-
-        campaignLogEl.innerHTML = `<h4>Lever log</h4><ul>${logItems.map(item => `<li>${item}</li>`).join('')}</ul>`;
-      }
-
-      function setPolicy(policy) {
-        currentPolicy = policy;
-        scenarioButtons.forEach(button => {
-          const isActive = button.dataset.scenario === policy;
-          button.classList.toggle('active', isActive);
-          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
-        hybridRow.hidden = currentPolicy !== 'hybrid';
-        updateLab();
-      }
-
-      themeToggle.addEventListener('click', () => {
-        const isCivil = !lab.classList.contains('civil-war');
-        applyTheme(isCivil);
-        updateLab();
-      });
-
-      scenarioButtons.forEach(button => {
-        button.addEventListener('click', () => setPolicy(button.dataset.scenario));
-      });
-
-      compWeightSlider.addEventListener('input', () => {
-        compWeightValue.textContent = `${compWeightSlider.value}%`;
-        updateLab();
-      });
-
-      [outsourcerToggle, stemToggle, phdToggle].forEach(toggle => toggle.addEventListener('change', updateLab));
-
-      setPolicy(currentPolicy);
-    })();
-  </script>
-</body>
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<App />);
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- move policy and lever controls into a sticky top control panel so adjustments are always visible
- add an enhanced hybrid weighting slider with live value display and narrative guidance
- refresh scenario and lever styling for a cleaner responsive layout that matches the new panel design

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d89b452cd4832f890c84358ab1e98f